### PR TITLE
Ubuntu focal 20.04 lts

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,14 @@
 
 ## Requirements
 
-The scripts require qemu-arm-static and binfmt being set up properly.
+- The scripts require qemu-arm-static and binfmt being set up properly.
+- Only works on Ubuntu 20.04(tested) and Ubuntu based Linux distribution
 
 ```sh
 sudo apt-get update
 sudo apt-get install qemu binfmt-support qemu binfmt-support qemu-user-static
 sudo apt-get install flex bison zerofree u-boot-tools
+sudo apt install debootstrap
 ```
 
 ## Flow

--- a/packages.basic.txt
+++ b/packages.basic.txt
@@ -78,7 +78,8 @@ opencl-headers
 libelf1
 #libelf-dev -- conflict
 'libconfig++9v5' 'libconfig++-dev' libconfig-dev libconfig9
-libevent-2.1.6 libevent-dev
+#libevent-2.1.* will be installed by libevent-dev depends.
+libevent-dev
 
 # Needed for parallella-utils xtemp
 libx11-6
@@ -87,6 +88,6 @@ i2c-tools
 
 # OpenMPI
 libopenmpi-dev
-libopenmpi2
+libopenmpi3
 openmpi-bin
 openmpi-common

--- a/rootfs-arm.sh
+++ b/rootfs-arm.sh
@@ -33,7 +33,7 @@ dpkg -i /tmp/deb-pkgs/*.deb
 
 echo fixing libelf symlink for coprthr
 #HACK HACK HACK
-(cd /usr/lib/arm-linux-gnueabihf/ && ln -sf libelf.so.0.8.13 libelf.so)
+(cd /usr/lib/arm-linux-gnueabihf/ && ln -sf libelf.so.1 libelf.so)
 
 
 echo Fixing zoneinfo

--- a/rootfs-arm.sh
+++ b/rootfs-arm.sh
@@ -17,6 +17,13 @@ cd $top
 export LC_ALL=C
 export DEBIAN_FRONTEND=noninteractive
 
+echo add 'universe' to sources.list
+#add-apt-repository "deb http://deb.torproject.org/torproject.org $(lsb_release -s -c) universe"
+echo "deb http://ports.ubuntu.com/ubuntu-ports $(lsb_release -s -c) universe" >> /etc/apt/sources.list
+
+echo Updating packages
+apt-get update -yy || true
+
 echo Installing local deb packages
 apt-get install -yy multiarch-support
 dpkg -i /tmp/deb-pkgs/*.deb
@@ -25,8 +32,6 @@ echo fixing libelf symlink for coprthr
 #HACK HACK HACK
 (cd /usr/lib/arm-linux-gnueabihf/ && ln -sf libelf.so.0.8.13 libelf.so)
 
-echo Updating packages
-apt-get update -yy || true
 
 echo Fixing zoneinfo
 # Set Zonedata so the interactive prompt won't pop up while installing packages

--- a/rootfs-arm.sh
+++ b/rootfs-arm.sh
@@ -25,7 +25,10 @@ echo Updating packages
 apt-get update -yy || true
 
 echo Installing local deb packages
-apt-get install -yy multiarch-support
+apt-get install -yy wget
+wget -P /tmp/ http://ftp.us.debian.org/debian/pool/main/g/glibc/multiarch-support_2.28-10_armhf.deb 
+#apt-get install -yy multiarch-support
+dpkg -i /tmp/multiarch-support*.deb
 dpkg -i /tmp/deb-pkgs/*.deb
 
 echo fixing libelf symlink for coprthr

--- a/rootfs-arm.sh
+++ b/rootfs-arm.sh
@@ -48,8 +48,6 @@ touch /etc/dhcp/dhclient.conf
 apt-get install -o Dpkg::Options::="--force-confold" -o Dpkg::Options::="--force-confdef" --force-yes -yy \
 	isc-dhcp-client isc-dhcp-common
 
-echo Unminimize Ubuntu install
-yes | unminimize || true # Will fail in restart hook
 
 echo Upgrading packages
 apt-get dist-upgrade -yy

--- a/rootfs.sh
+++ b/rootfs.sh
@@ -49,17 +49,6 @@ unset LC_ALL
 unset LC_TIME
 export LC_ALL=C
 
-if ! [ -e ${ubuntu_tarball} ]; then
-	echo Downloading Ubuntu Base tarball
-	wget ${UBUNTU_URL} -O ${ubuntu_tarball}
-fi
-
-echo Checking md5sums
-if ! md5sum -c md5sum.txt; then
-	echo md5sum fail
-	exit 1
-fi
-
 echo Removing old rootfs image
 rm -rf ${root_image} ${root_image}.gz
 
@@ -78,8 +67,8 @@ echo Mounting root filesystem
 mkdir -p ${root_mnt}
 mount ${root_dev} ${root_mnt}
 
-echo Unpacking Ubuntu tarball
-tar xfzp ${ubuntu_tarball} -C ${root_mnt} --strip-components 0
+echo fetching Ubuntu focal
+sudo debootstrap --arch=armhf focal ${root_mnt}
 
 echo Applying overlays
 #TODO: Use tarballs (for owner/group)?

--- a/rootfs.sh
+++ b/rootfs.sh
@@ -157,6 +157,22 @@ cp -r tests ${root_mnt}/home/parallella/
 echo Copying debian packages
 cp -rv ${top}/deb-pkgs ${root_mnt}/tmp/
 
+# Ubuntu 20.04 uses symlinks to /usr for /bin, /sbin and /lib
+# after applying overlays, it change bin lib to a regular folder
+fixSymbLink () {
+	if [[ -e "${root_mnt}/$1" && ! -L "${root_mnt}/$1" ]]
+	then
+	    echo Fixing symbolic link $1
+	    pushd ${root_mnt}
+	    rsync -ap --no-owner --no-group $1/ usr/$1
+	    rm -rf $1
+	    ln -sf usr/$1
+	    popd	    
+	fi
+}
+fixSymbLink bin
+fixSymbLink lib
+
 echo Starting ARM chroot
 chroot ${root_mnt} ./tmp/rootfs-arm.sh
 #chroot ${root_mnt}

--- a/settings.inc.sh
+++ b/settings.inc.sh
@@ -5,14 +5,10 @@ set -u
 
 mkdir -p ${top}/out
 
-UBUNTU_URL="http://cdimage.ubuntu.com/ubuntu-base/releases/bionic/release/ubuntu-base-18.04.2-base-armhf.tar.gz"
-UBUNTU_TARBALL_NAME=ubuntu_base.tgz
-
 root_mnt=${top}/mnt/rootfs
 boot_mnt=${top}/mnt/boot
 root_image=${top}/out/root.image
 boot_image=${top}/out/boot.image
-ubuntu_tarball=${top}/${UBUNTU_TARBALL_NAME}
 image_file=${top}/out/image
 # Offsets and sizes hardcoded. See sfdisk-script.txt
 image_size=7200


### PR DESCRIPTION
Update to Ubuntu focal 20.04 LTS

Using debootstrap to fetch Ubuntu. Tested on Ubuntu 20.04 and Parallella Embedded Zynq 7020.